### PR TITLE
Add missing quote to default config string

### DIFF
--- a/spacy_wrap/pipeline_component.py
+++ b/spacy_wrap/pipeline_component.py
@@ -44,7 +44,7 @@ DEFAULT_CONFIG_STR = """
 max_batch_items = 4096
 doc_extension_trf_data = "clf_trf_data"
 doc_extension_prediction = "classification"
-labels = ["positive", negative"]
+labels = ["positive", "negative"]
 
 [classification_transformer.set_extra_annotations]
 @annotation_setters = "spacy-transformers.null_annotation_setter.v1"


### PR DESCRIPTION
The `labels` list was missing a double quote, so `Config().from_str(...)` was interpreting labels as a string and not a list.