### PR TITLE
Updated about.py

### DIFF
--- a/src/spacy_wrap/about.py
+++ b/src/spacy_wrap/about.py
@@ -1,4 +1,4 @@
-from importlib.metadata import version
+from importlib_metadata import version
 
 __title__ = "spacy-wrap"
 __version__ = version("spacy_wrap")


### PR DESCRIPTION
import `spacy_wrap` gave me this error

```
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
/tmp/ipykernel_28/1868617782.py in <module>
      1 import spacy
----> 2 import spacy_wrap
      3 
      4 nlp = spacy.blank("en")
      5 

/opt/conda/lib/python3.7/site-packages/spacy_wrap/__init__.py in <module>
----> 1 from .about import __documentation__, __download_url__, __title__  # noqa
      2 from .architectures import (  # noqa
      3     create_SequenceClassificationTransformerModel_v1,
      4     create_TokenClassificationTransformerModel_v1,
      5 )

/opt/conda/lib/python3.7/site-packages/spacy_wrap/about.py in <module>
----> 1 from importlib.metadata import version
      2 
      3 __version__ = version("spacy_wrap")
      4 __title__ = "spacy-wrap"
      5 __download_url__ = "https://github.com/kennethenevoldsen/spacy-wrap"

ModuleNotFoundError: No module named 'importlib.metadata'
```
I changed it from from `importlib.metadata import version` to `from importlib_metadata import version`